### PR TITLE
feat: add Bind-on-start for Ghostty tab focus without tmux

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,10 @@ Sources/
 │   ├── SessionStore.swift     # Session CRUD
 │   ├── TtyDetector.swift      # TTY detection
 │   ├── SetupManager.swift     # First-run setup, hooks
+│   ├── TerminalAdapter.swift  # Terminal adapter protocol
+│   ├── GhosttyHelper.swift    # Ghostty tab control (Accessibility API)
+│   ├── ITerm2Helper.swift     # iTerm2 tab control (AppleScript TTY search)
+│   ├── TmuxHelper.swift       # tmux pane control
 │   └── DebugLog.swift         # Debug logging
 ├── Models/
 │   ├── Session.swift          # Session model
@@ -45,9 +49,12 @@ Sources/
 pkill -f CCStatusBar
 swift build
 cp .build/debug/CCStatusBar CCStatusBar.app/Contents/MacOS/
-codesign --force --deep --sign - CCStatusBar.app
+codesign --force --deep --sign "CCStatusBar Dev" CCStatusBar.app
 open CCStatusBar.app
 ```
+
+**Note**: Use self-signed certificate "CCStatusBar Dev" to preserve Accessibility permissions across rebuilds.
+See `plans/crystalline-humming-stardust.md` for certificate setup and distribution signing requirements.
 
 ## Data Source
 

--- a/README.md
+++ b/README.md
@@ -24,10 +24,47 @@ On first launch, the app automatically:
 - Registers hooks in `~/.claude/settings.json`
 - Creates backup of existing settings
 
+## Supported Environments
+
+### Fully Supported
+| Environment | Features |
+|-------------|----------|
+| **Ghostty + tmux** | Full tab switching and pane focus |
+| **iTerm2** | Full tab switching by TTY (with or without tmux) |
+
+### Ghostty without tmux
+By default, Claude Code overrides tab titles to `✳ Claude Code`, making tab switching unreliable.
+
+**Solution:** Disable title changes in Claude Code settings:
+```json
+// ~/.claude/settings.json
+{
+  "env": {
+    "CLAUDE_CODE_DISABLE_TERMINAL_TITLE": "1"
+  }
+}
+```
+
+This preserves project-based tab titles and enables reliable tab switching.
+
+### Partially Supported
+| Environment | Features |
+|-------------|----------|
+| **Terminal.app + tmux** | Pane focus only |
+
+### Not Supported
+- VS Code integrated terminal (limited external API)
+- Warp (limited external tab control API)
+- Non-tmux environments with multiple tabs (TTY identification difficult)
+
+### Future Plans
+See [plans/crystalline-humming-stardust.md](plans/crystalline-humming-stardust.md) for roadmap.
+
 ## Requirements
 
 - macOS 13.0+
 - Claude Code CLI
+- Accessibility permission (for Ghostty tab switching)
 
 ## Installation
 

--- a/Sources/Models/Session.swift
+++ b/Sources/Models/Session.swift
@@ -7,6 +7,7 @@ struct Session: Codable, Identifiable {
     var status: SessionStatus
     let createdAt: Date
     var updatedAt: Date
+    var ghosttyTabIndex: Int?  // Bind-on-start: tab index at session start
 
     var id: String {
         tty.map { "\(sessionId):\($0)" } ?? sessionId
@@ -27,5 +28,6 @@ struct Session: Codable, Identifiable {
         case status
         case createdAt = "created_at"
         case updatedAt = "updated_at"
+        case ghosttyTabIndex = "ghostty_tab_index"
     }
 }

--- a/Sources/Services/ITerm2Helper.swift
+++ b/Sources/Services/ITerm2Helper.swift
@@ -1,0 +1,106 @@
+import AppKit
+
+// MARK: - ITerm2Adapter (TerminalAdapter conformance)
+
+/// Adapter implementation for iTerm2 terminal
+final class ITerm2Adapter: TerminalAdapter {
+    let name = "iTerm2"
+    let bundleIdentifier = ITerm2Helper.bundleIdentifier
+    let capabilities: TerminalCapabilities = [.focusByTTY, .activateOnly]
+
+    var isRunning: Bool {
+        ITerm2Helper.isRunning
+    }
+
+    func focusSession(_ sessionName: String) -> Bool {
+        // iTerm2 does not support title-based search in this implementation
+        // Use focusByTTY instead
+        false
+    }
+
+    func focusByTTY(_ tty: String) -> Bool {
+        ITerm2Helper.focusSessionByTTY(tty)
+    }
+
+    func activate() -> Bool {
+        ITerm2Helper.activate()
+    }
+}
+
+// MARK: - ITerm2Helper (static API)
+
+enum ITerm2Helper {
+    static let bundleIdentifier = "com.googlecode.iterm2"
+
+    /// Check if iTerm2 is running
+    static var isRunning: Bool {
+        !NSRunningApplication.runningApplications(
+            withBundleIdentifier: bundleIdentifier
+        ).isEmpty
+    }
+
+    /// Get iTerm2's running application instance
+    static var runningApp: NSRunningApplication? {
+        NSRunningApplication.runningApplications(
+            withBundleIdentifier: bundleIdentifier
+        ).first
+    }
+
+    /// Focus session by TTY using AppleScript whose clause (Gemini optimized)
+    /// - Parameter tty: The TTY device path (e.g., "/dev/ttys002")
+    /// - Returns: true if successfully focused
+    static func focusSessionByTTY(_ tty: String) -> Bool {
+        // Escape the TTY string for AppleScript
+        let escapedTTY = tty.replacingOccurrences(of: "\"", with: "\\\"")
+
+        let script = """
+            tell application "iTerm"
+                try
+                    set targetSession to (first session of every tab of every window whose tty is "\(escapedTTY)")
+                    tell targetSession
+                        select
+                    end tell
+                    activate
+                    return "true"
+                on error errMsg
+                    return "false"
+                end try
+            end tell
+            """
+
+        guard let appleScript = NSAppleScript(source: script) else {
+            DebugLog.log("[ITerm2Helper] Failed to create AppleScript")
+            return false
+        }
+
+        var error: NSDictionary?
+        let result = appleScript.executeAndReturnError(&error)
+
+        if let error = error {
+            DebugLog.log("[ITerm2Helper] AppleScript error: \(error)")
+            return false
+        }
+
+        let success = result.stringValue == "true"
+        if success {
+            DebugLog.log("[ITerm2Helper] Successfully focused session with TTY '\(tty)'")
+        } else {
+            DebugLog.log("[ITerm2Helper] Could not find session with TTY '\(tty)'")
+        }
+
+        return success
+    }
+
+    /// Activate iTerm2 (bring to front)
+    /// - Returns: true if successfully activated
+    static func activate() -> Bool {
+        guard let app = runningApp else {
+            DebugLog.log("[ITerm2Helper] iTerm2 not running")
+            return false
+        }
+
+        app.activate(options: [.activateIgnoringOtherApps])
+        DebugLog.log("[ITerm2Helper] Activated iTerm2")
+        return true
+    }
+}

--- a/Sources/Services/SessionStore.swift
+++ b/Sources/Services/SessionStore.swift
@@ -57,13 +57,26 @@ final class SessionStore {
             existing.updatedAt = now
             session = existing
         } else {
+            // New session - capture Ghostty tab index for Bind-on-start
+            var tabIndex: Int? = nil
+            if event.hookEventName == .sessionStart && GhosttyHelper.isRunning {
+                // Only bind tab for non-tmux sessions (tmux uses title search)
+                if let tty = event.tty, TmuxHelper.getPaneInfo(for: tty) == nil {
+                    tabIndex = GhosttyHelper.getSelectedTabIndex()
+                    if let idx = tabIndex {
+                        DebugLog.log("[SessionStore] Bind-on-start: captured tab index \(idx) for session \(event.sessionId)")
+                    }
+                }
+            }
+
             session = Session(
                 sessionId: event.sessionId,
                 cwd: event.cwd,
                 tty: event.tty,
                 status: determineStatus(event: event, current: nil),
                 createdAt: now,
-                updatedAt: now
+                updatedAt: now,
+                ghosttyTabIndex: tabIndex
             )
         }
 

--- a/Sources/Services/TerminalAdapter.swift
+++ b/Sources/Services/TerminalAdapter.swift
@@ -1,0 +1,74 @@
+import Foundation
+
+/// Terminal adapter capabilities
+struct TerminalCapabilities: OptionSet {
+    let rawValue: Int
+
+    /// Can focus a session by name (tab title search)
+    static let focusBySession = TerminalCapabilities(rawValue: 1 << 0)
+
+    /// Can focus a session by TTY (for tmux integration)
+    static let focusByTTY = TerminalCapabilities(rawValue: 1 << 1)
+
+    /// Can only activate the app (bring to front)
+    static let activateOnly = TerminalCapabilities(rawValue: 1 << 2)
+}
+
+/// Protocol for terminal adapters
+/// Enables support for multiple terminal emulators (Ghostty, iTerm2, etc.)
+protocol TerminalAdapter {
+    /// Display name of the terminal
+    var name: String { get }
+
+    /// Bundle identifier for the terminal app
+    var bundleIdentifier: String { get }
+
+    /// Capabilities supported by this terminal
+    var capabilities: TerminalCapabilities { get }
+
+    /// Whether the terminal app is currently running
+    var isRunning: Bool { get }
+
+    /// Focus a session by name (tab title search)
+    /// - Parameter sessionName: The name to search for in tab titles
+    /// - Returns: true if successfully focused
+    func focusSession(_ sessionName: String) -> Bool
+
+    /// Focus a session by TTY device path
+    /// - Parameter tty: The TTY device path (e.g., "/dev/ttys002")
+    /// - Returns: true if successfully focused
+    func focusByTTY(_ tty: String) -> Bool
+
+    /// Activate the terminal app (bring to front)
+    /// - Returns: true if successfully activated
+    func activate() -> Bool
+}
+
+// MARK: - Default implementations
+
+extension TerminalAdapter {
+    /// Default implementation: TTY-based focus not supported
+    func focusByTTY(_ tty: String) -> Bool {
+        false
+    }
+}
+
+/// Registry of available terminal adapters
+enum TerminalRegistry {
+    /// Available adapters in priority order (iTerm2 first for TTY-based search)
+    static let adapters: [TerminalAdapter] = [
+        ITerm2Adapter(),
+        GhosttyAdapter()
+        // Future: TerminalAppAdapter()
+    ]
+
+    /// Find the first running terminal
+    static func findRunningTerminal() -> TerminalAdapter? {
+        adapters.first { $0.isRunning }
+    }
+
+    /// Find a specific terminal by name
+    static func findTerminal(named name: String) -> TerminalAdapter? {
+        adapters.first { $0.name.lowercased() == name.lowercased() }
+    }
+}


### PR DESCRIPTION
## Summary
- Add Bind-on-start mechanism to capture Ghostty tab index when Claude Code session starts
- Implement iTerm2 TTY-based session search for reliable tab switching
- Add TerminalAdapter protocol for future terminal support extensibility
- Add debug menu to dump Ghostty AX attributes for investigation

## Test plan
- [x] Test Ghostty + tmux: Tab focus works via title search
- [x] Test Ghostty without tmux: Tab focus works via Bind-on-start tab index
- [ ] Test iTerm2: Tab focus works via TTY search (deferred - no iTerm2 available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)