### PR TITLE
feat: add color theme customization for menu bar

### DIFF
--- a/Sources/CCStatusBarLib/App/AppDelegate.swift
+++ b/Sources/CCStatusBarLib/App/AppDelegate.swift
@@ -489,13 +489,34 @@ public class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
         for theme in ColorTheme.allCases {
             let item = NSMenuItem(
-                title: theme.displayName,
+                title: "",
                 action: #selector(setColorTheme(_:)),
                 keyEquivalent: ""
             )
             item.target = self
             item.representedObject = theme
             item.state = (currentTheme == theme) ? .on : .off
+
+            // Build attributed title with 4 color dots + theme name
+            let attributed = NSMutableAttributedString()
+            let dotFont = NSFont.systemFont(ofSize: 12)
+            let textFont = NSFont.systemFont(ofSize: 13)
+
+            // Add 4 color dots: red, yellow, green, white
+            for color in [theme.redColor, theme.yellowColor, theme.greenColor, theme.whiteColor] {
+                attributed.append(NSAttributedString(
+                    string: "●",
+                    attributes: [.foregroundColor: color, .font: dotFont]
+                ))
+            }
+
+            // Add space and theme name
+            attributed.append(NSAttributedString(
+                string: "  \(theme.displayName)",
+                attributes: [.foregroundColor: NSColor.labelColor, .font: textFont]
+            ))
+
+            item.attributedTitle = attributed
             menu.addItem(item)
         }
 

--- a/Sources/CCStatusBarLib/App/AppDelegate.swift
+++ b/Sources/CCStatusBarLib/App/AppDelegate.swift
@@ -157,15 +157,16 @@ public class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         let totalCount = redCount + yellowCount + greenCount
 
         // "CC" color: red > yellow > green > white priority
+        let theme = AppSettings.colorTheme
         let ccColor: NSColor
         if redCount > 0 {
-            ccColor = .systemRed
+            ccColor = theme.redColor
         } else if yellowCount > 0 {
-            ccColor = .systemYellow
+            ccColor = theme.yellowColor
         } else if greenCount > 0 {
-            ccColor = .systemGreen
+            ccColor = theme.greenColor
         } else {
-            ccColor = .white
+            ccColor = theme.whiteColor
         }
 
         // No spinner in menu bar - just static "CC"
@@ -188,12 +189,12 @@ public class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             attributed.append(NSAttributedString(string: " "))
             attributed.append(NSAttributedString(
                 string: "\(redCount)",
-                attributes: [.foregroundColor: NSColor.systemRed, .font: font]
+                attributes: [.foregroundColor: theme.redColor, .font: font]
             ))
             if yellowCount + greenCount > 0 {
                 attributed.append(NSAttributedString(
                     string: "/\(totalCount)",
-                    attributes: [.foregroundColor: NSColor.white, .font: font]
+                    attributes: [.foregroundColor: theme.whiteColor, .font: font]
                 ))
             }
         } else if yellowCount > 0 {
@@ -201,12 +202,12 @@ public class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
             attributed.append(NSAttributedString(string: " "))
             attributed.append(NSAttributedString(
                 string: "\(yellowCount)",
-                attributes: [.foregroundColor: NSColor.systemYellow, .font: font]
+                attributes: [.foregroundColor: theme.yellowColor, .font: font]
             ))
             if greenCount > 0 {
                 attributed.append(NSAttributedString(
                     string: "/\(totalCount)",
-                    attributes: [.foregroundColor: NSColor.white, .font: font]
+                    attributes: [.foregroundColor: theme.whiteColor, .font: font]
                 ))
             }
         } else if greenCount > 0 {
@@ -360,6 +361,11 @@ public class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         webServerItem.state = WebServer.shared.isRunning ? .on : .off
         menu.addItem(webServerItem)
 
+        // Color Theme submenu
+        let colorThemeItem = NSMenuItem(title: "Color Theme", action: nil, keyEquivalent: "")
+        colorThemeItem.submenu = createColorThemeMenu()
+        menu.addItem(colorThemeItem)
+
         menu.addItem(NSMenuItem.separator())
 
         // Permissions submenu
@@ -477,6 +483,32 @@ public class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         return menu
     }
 
+    private func createColorThemeMenu() -> NSMenu {
+        let menu = NSMenu()
+        let currentTheme = AppSettings.colorTheme
+
+        for theme in ColorTheme.allCases {
+            let item = NSMenuItem(
+                title: theme.displayName,
+                action: #selector(setColorTheme(_:)),
+                keyEquivalent: ""
+            )
+            item.target = self
+            item.representedObject = theme
+            item.state = (currentTheme == theme) ? .on : .off
+            menu.addItem(item)
+        }
+
+        return menu
+    }
+
+    @MainActor @objc private func setColorTheme(_ sender: NSMenuItem) {
+        guard let theme = sender.representedObject as? ColorTheme else { return }
+        AppSettings.colorTheme = theme
+        DebugLog.log("[AppDelegate] Color theme set to: \(theme.displayName)")
+        refreshUI()
+    }
+
     @objc private func toggleLaunchAtLogin(_ sender: NSMenuItem) {
         do {
             let newState = !LaunchManager.isEnabled
@@ -547,18 +579,19 @@ public class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         }
 
         // Symbol color: gray for detached tmux, red for permission_prompt, yellow for stop/unknown, green for running/acknowledged
+        let theme = AppSettings.colorTheme
         let symbolColor: NSColor
         if isTmuxDetached {
             symbolColor = .tertiaryLabelColor  // Grayed out for detached tmux
         } else if !isAcknowledged && session.status == .waitingInput {
             // Unacknowledged waiting: red for permission_prompt, yellow otherwise
-            symbolColor = (session.waitingReason == .permissionPrompt) ? .systemRed : .systemYellow
+            symbolColor = (session.waitingReason == .permissionPrompt) ? theme.redColor : theme.yellowColor
         } else {
             switch displayStatus {
             case .running:
-                symbolColor = .systemGreen
+                symbolColor = theme.greenColor
             case .waitingInput:
-                symbolColor = .systemYellow  // Fallback (shouldn't reach here if acknowledged)
+                symbolColor = theme.yellowColor  // Fallback (shouldn't reach here if acknowledged)
             case .stopped:
                 symbolColor = .systemGray
             }

--- a/Sources/CCStatusBarLib/Services/AppSettings.swift
+++ b/Sources/CCStatusBarLib/Services/AppSettings.swift
@@ -7,6 +7,7 @@ enum AppSettings {
         static let sessionTimeoutMinutes = "sessionTimeoutMinutes"
         static let webServerEnabled = "webServerEnabled"
         static let webServerPort = "webServerPort"
+        static let colorTheme = "colorTheme"
     }
 
     static var launchAtLogin: Bool {
@@ -56,5 +57,13 @@ enum AppSettings {
             return UserDefaults.standard.integer(forKey: Keys.webServerPort)
         }
         set { UserDefaults.standard.set(newValue, forKey: Keys.webServerPort) }
+    }
+
+    static var colorTheme: ColorTheme {
+        get {
+            let raw = UserDefaults.standard.string(forKey: Keys.colorTheme) ?? "vibrant"
+            return ColorTheme(rawValue: raw) ?? .vibrant
+        }
+        set { UserDefaults.standard.set(newValue.rawValue, forKey: Keys.colorTheme) }
     }
 }

--- a/Sources/CCStatusBarLib/Services/ColorTheme.swift
+++ b/Sources/CCStatusBarLib/Services/ColorTheme.swift
@@ -60,8 +60,17 @@ public enum ColorTheme: String, CaseIterable {
         }
     }
 
-    /// Color for idle/no sessions (white) - same across all themes
+    /// Color for idle/no sessions
     public var whiteColor: NSColor {
-        return .white
+        switch self {
+        case .vibrant:
+            return .white
+        case .muted:
+            return NSColor(red: 0.90, green: 0.87, blue: 0.82, alpha: 1.0)  // Warm gray #E6DED1
+        case .warm:
+            return NSColor(red: 1.0, green: 0.95, blue: 0.88, alpha: 1.0)   // Soft cream #FFF2E0
+        case .cool:
+            return NSColor(red: 0.85, green: 0.90, blue: 0.95, alpha: 1.0)  // Soft blue-gray #D9E6F2
+        }
     }
 }

--- a/Sources/CCStatusBarLib/Services/ColorTheme.swift
+++ b/Sources/CCStatusBarLib/Services/ColorTheme.swift
@@ -1,0 +1,67 @@
+import AppKit
+
+/// Color theme presets for menu bar status display
+public enum ColorTheme: String, CaseIterable {
+    case vibrant   // Original bright system colors
+    case muted     // Softer colors (especially yellow -> tan)
+    case warm      // Orange-tinted palette
+    case cool      // Cyan/teal palette
+
+    public var displayName: String {
+        switch self {
+        case .vibrant: return "Vibrant"
+        case .muted: return "Muted"
+        case .warm: return "Warm"
+        case .cool: return "Cool"
+        }
+    }
+
+    // MARK: - Status Colors
+
+    /// Color for permission_prompt (red) status
+    public var redColor: NSColor {
+        switch self {
+        case .vibrant:
+            return .systemRed
+        case .muted:
+            return NSColor(red: 0.898, green: 0.451, blue: 0.451, alpha: 1.0)  // Salmon #E57373
+        case .warm:
+            return NSColor(red: 1.0, green: 0.439, blue: 0.263, alpha: 1.0)    // Coral #FF7043
+        case .cool:
+            return NSColor(red: 0.957, green: 0.561, blue: 0.694, alpha: 1.0)  // Pink #F48FB1
+        }
+    }
+
+    /// Color for waiting_input (yellow) status
+    public var yellowColor: NSColor {
+        switch self {
+        case .vibrant:
+            return .systemYellow
+        case .muted:
+            return NSColor(red: 0.831, green: 0.647, blue: 0.455, alpha: 1.0)  // Tan #D4A574
+        case .warm:
+            return NSColor(red: 1.0, green: 0.718, blue: 0.302, alpha: 1.0)    // Orange #FFB74D
+        case .cool:
+            return NSColor(red: 0.302, green: 0.816, blue: 0.882, alpha: 1.0)  // Cyan #4DD0E1
+        }
+    }
+
+    /// Color for running (green) status
+    public var greenColor: NSColor {
+        switch self {
+        case .vibrant:
+            return .systemGreen
+        case .muted:
+            return NSColor(red: 0.506, green: 0.780, blue: 0.518, alpha: 1.0)  // Sage #81C784
+        case .warm:
+            return NSColor(red: 0.682, green: 0.835, blue: 0.506, alpha: 1.0)  // Lime #AED581
+        case .cool:
+            return NSColor(red: 0.302, green: 0.714, blue: 0.675, alpha: 1.0)  // Teal #4DB6AC
+        }
+    }
+
+    /// Color for idle/no sessions (white) - same across all themes
+    public var whiteColor: NSColor {
+        return .white
+    }
+}

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -195,6 +195,12 @@ Settings >
 │   ├── 6 hours
 │   └── Never
 ├── Global Hotkey (toggle) ← shows ⌘⇧C when enabled
+├── Web Server (toggle) ← shows port when enabled
+├── Color Theme >
+│   ├── Vibrant ← default
+│   ├── Muted
+│   ├── Warm
+│   └── Cool
 ├── ─────────────
 ├── Permissions >
 │   ├── ✓/✗ Accessibility status
@@ -697,3 +703,50 @@ Attach states are cached for 5 seconds to avoid excessive tmux commands.
 - **Methods**: `getSessionAttachStates()`, `isSessionAttached(_:)`
 - **File**: `Sources/App/AppDelegate.swift`
 - **Method**: `createSessionMenuItem(_:)`, `createSessionActionsMenu(session:isAcknowledged:isTmuxDetached:)`, `copyAttachCommand(_:)`
+
+---
+
+## 19. Color Theme
+
+### 19.1 Purpose
+
+Customize menu bar status colors for better visibility and aesthetic preference. Addresses feedback that default yellow is too harsh/bright.
+
+### 19.2 Available Themes
+
+| Theme | Description |
+|-------|-------------|
+| Vibrant | Original bright system colors (systemRed, systemYellow, systemGreen) |
+| Muted | Softer colors, especially yellow → tan |
+| Warm | Orange-tinted palette |
+| Cool | Cyan/teal palette |
+
+### 19.3 Color Mapping
+
+| Status | Vibrant | Muted | Warm | Cool |
+|--------|---------|-------|------|------|
+| Red | systemRed | Salmon (#E57373) | Coral (#FF7043) | Pink (#F48FB1) |
+| Yellow | systemYellow | Tan (#D4A574) | Orange (#FFB74D) | Cyan (#4DD0E1) |
+| Green | systemGreen | Sage (#81C784) | Lime (#AED581) | Teal (#4DB6AC) |
+| White | white | white | white | white |
+
+### 19.4 Storage
+
+- Key: `colorTheme`
+- Storage: UserDefaults
+- Default: `vibrant`
+
+### 19.5 Affected Elements
+
+- Menu bar "CC" text color
+- Menu bar count display colors
+- Session list symbol colors
+
+### 19.6 Implementation
+
+- **File**: `Sources/Services/ColorTheme.swift`
+- **Enum**: `ColorTheme`
+- **File**: `Sources/Services/AppSettings.swift`
+- **Property**: `colorTheme`
+- **File**: `Sources/App/AppDelegate.swift`
+- **Methods**: `updateStatusTitle()`, `createSessionMenuItem(_:)`, `createColorThemeMenu()`, `setColorTheme(_:)`

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -728,7 +728,11 @@ Customize menu bar status colors for better visibility and aesthetic preference.
 | Red | systemRed | Salmon (#E57373) | Coral (#FF7043) | Pink (#F48FB1) |
 | Yellow | systemYellow | Tan (#D4A574) | Orange (#FFB74D) | Cyan (#4DD0E1) |
 | Green | systemGreen | Sage (#81C784) | Lime (#AED581) | Teal (#4DB6AC) |
-| White | white | white | white | white |
+| White | white | Warm gray (#E6DED1) | Soft cream (#FFF2E0) | Soft blue-gray (#D9E6F2) |
+
+### 19.4 Menu Display
+
+Each theme shows 4 color preview dots (●●●●) before the theme name in the Color Theme submenu.
 
 ### 19.4 Storage
 


### PR DESCRIPTION
Fixes #3

## Summary

- Add 4 color theme presets to address harsh yellow indicator feedback
- **Vibrant**: Original system colors (default)
- **Muted**: Softer colors, especially yellow → tan
- **Warm**: Orange-tinted palette  
- **Cool**: Cyan/teal palette

## Implementation

- New `ColorTheme.swift` enum with color definitions
- Theme selection via `Settings > Color Theme` submenu
- Theme applied to menu bar title and session list icons
- Setting persisted in UserDefaults

## Test plan

- [x] Build succeeds
- [x] Unit tests pass
- [ ] Switch themes via Settings menu
- [ ] Verify colors change in menu bar
- [ ] Verify setting persists across restart