### PR TITLE
feat: Codex CLI tracking and 2-row menu bar icon

### DIFF
--- a/Sources/CCStatusBarLib/Models/CodexSession.swift
+++ b/Sources/CCStatusBarLib/Models/CodexSession.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Represents an active Codex CLI session
+struct CodexSession: Equatable {
+    let pid: pid_t
+    let cwd: String
+    let projectName: String
+    let startedAt: Date
+
+    /// Session ID from Codex session file (if found)
+    var sessionId: String?
+
+    init(pid: pid_t, cwd: String, sessionId: String? = nil) {
+        self.pid = pid
+        self.cwd = cwd
+        self.projectName = URL(fileURLWithPath: cwd).lastPathComponent
+        self.startedAt = Date()
+        self.sessionId = sessionId
+    }
+}
+
+/// Information about Codex session for WebSocket output
+struct CodexInfo: Codable {
+    let pid: pid_t
+    let isActive: Bool
+    let startedAt: Date?
+    let sessionId: String?
+
+    enum CodingKeys: String, CodingKey {
+        case pid
+        case isActive = "is_active"
+        case startedAt = "started_at"
+        case sessionId = "session_id"
+    }
+}

--- a/Sources/CCStatusBarLib/Services/CodexObserver.swift
+++ b/Sources/CCStatusBarLib/Services/CodexObserver.swift
@@ -1,0 +1,214 @@
+import Foundation
+import Combine
+
+/// Observes active Codex CLI sessions by monitoring running processes
+/// Matches Codex sessions with Claude Code sessions by cwd
+enum CodexObserver {
+    // MARK: - Cache
+
+    /// Cache for active Codex sessions (TTL: 5 seconds)
+    private static var sessionsCache: (sessions: [String: CodexSession], timestamp: Date)?
+    private static let cacheTTL: TimeInterval = 5.0
+
+    /// Invalidate the cache
+    static func invalidateCache() {
+        sessionsCache = nil
+        DebugLog.log("[CodexObserver] Cache invalidated")
+    }
+
+    // MARK: - Public API
+
+    /// Get all active Codex sessions indexed by cwd
+    /// - Returns: Dictionary of cwd -> CodexSession
+    static func getActiveSessions() -> [String: CodexSession] {
+        let now = Date()
+
+        // Check cache
+        if let cached = sessionsCache,
+           now.timeIntervalSince(cached.timestamp) < cacheTTL {
+            return cached.sessions
+        }
+
+        // Fetch from system
+        let sessions = fetchCodexSessions()
+        sessionsCache = (sessions, now)
+
+        if !sessions.isEmpty {
+            DebugLog.log("[CodexObserver] Found \(sessions.count) active Codex session(s)")
+        }
+
+        return sessions
+    }
+
+    /// Check if Codex is running for a specific cwd
+    /// - Parameter cwd: The working directory to check
+    /// - Returns: true if Codex is running in that directory
+    static func isCodexRunning(for cwd: String) -> Bool {
+        return getActiveSessions()[cwd] != nil
+    }
+
+    /// Get Codex session for a specific cwd
+    /// - Parameter cwd: The working directory
+    /// - Returns: CodexSession if running, nil otherwise
+    static func getCodexSession(for cwd: String) -> CodexSession? {
+        return getActiveSessions()[cwd]
+    }
+
+    /// Get CodexInfo for WebSocket output
+    /// - Parameter cwd: The working directory
+    /// - Returns: CodexInfo if Codex is running, nil otherwise
+    static func getCodexInfo(for cwd: String) -> CodexInfo? {
+        guard let session = getCodexSession(for: cwd) else {
+            return nil
+        }
+        return CodexInfo(
+            pid: session.pid,
+            isActive: true,
+            startedAt: session.startedAt,
+            sessionId: session.sessionId
+        )
+    }
+
+    // MARK: - Private
+
+    /// Fetch active Codex sessions from running processes
+    private static func fetchCodexSessions() -> [String: CodexSession] {
+        var sessions: [String: CodexSession] = [:]
+
+        // Get Codex process PIDs
+        // Pattern: /opt/homebrew/lib/node_modules/@openai/codex/vendor...codex
+        let pids = getCodexPIDs()
+
+        for pid in pids {
+            if let cwd = getCwd(for: pid) {
+                var session = CodexSession(pid: pid, cwd: cwd)
+
+                // Try to find session ID from Codex session files
+                session.sessionId = findCodexSessionId(for: cwd)
+
+                sessions[cwd] = session
+                DebugLog.log("[CodexObserver] Found Codex PID \(pid) in \(session.projectName)")
+            }
+        }
+
+        return sessions
+    }
+
+    /// Get PIDs of running Codex processes
+    private static func getCodexPIDs() -> [pid_t] {
+        // pgrep for codex vendor processes
+        let output = runCommand("/usr/bin/pgrep", ["-f", "codex/vendor.*codex"])
+        let pids = output
+            .split(separator: "\n")
+            .compactMap { pid_t($0.trimmingCharacters(in: .whitespaces)) }
+        return pids
+    }
+
+    /// Get current working directory for a process
+    private static func getCwd(for pid: pid_t) -> String? {
+        // lsof -p <pid> | grep cwd
+        let output = runCommand("/usr/sbin/lsof", ["-p", "\(pid)"])
+        for line in output.split(separator: "\n") {
+            let columns = line.split(separator: " ", omittingEmptySubsequences: true)
+            // lsof output: COMMAND PID USER FD TYPE DEVICE SIZE/OFF NODE NAME
+            // cwd line has FD="cwd" and NAME is the path
+            if columns.count >= 9,
+               columns[3] == "cwd" {
+                // NAME is the last column (may contain spaces)
+                let nameStartIndex = columns.index(columns.startIndex, offsetBy: 8)
+                let path = columns[nameStartIndex...].joined(separator: " ")
+                return path
+            }
+        }
+        return nil
+    }
+
+    /// Find Codex session ID from session files
+    /// Location: ~/.codex/sessions/YYYY/MM/DD/rollout-*.jsonl
+    private static func findCodexSessionId(for cwd: String) -> String? {
+        let homeDir = FileManager.default.homeDirectoryForCurrentUser
+        let sessionsDir = homeDir.appendingPathComponent(".codex/sessions")
+
+        // Get today's date components
+        let now = Date()
+        let calendar = Calendar.current
+        let year = calendar.component(.year, from: now)
+        let month = calendar.component(.month, from: now)
+        let day = calendar.component(.day, from: now)
+
+        let todayDir = sessionsDir
+            .appendingPathComponent(String(format: "%04d", year))
+            .appendingPathComponent(String(format: "%02d", month))
+            .appendingPathComponent(String(format: "%02d", day))
+
+        guard FileManager.default.fileExists(atPath: todayDir.path) else {
+            return nil
+        }
+
+        // Find rollout files
+        guard let files = try? FileManager.default.contentsOfDirectory(atPath: todayDir.path) else {
+            return nil
+        }
+
+        let rolloutFiles = files
+            .filter { $0.hasPrefix("rollout-") && $0.hasSuffix(".jsonl") }
+            .sorted()
+            .reversed()  // Most recent first
+
+        // Check each file for matching cwd
+        for filename in rolloutFiles {
+            let filePath = todayDir.appendingPathComponent(filename)
+            if let sessionId = parseCodexSessionFile(filePath, lookingForCwd: cwd) {
+                return sessionId
+            }
+        }
+
+        return nil
+    }
+
+    /// Parse a Codex session file to find session ID for a specific cwd
+    private static func parseCodexSessionFile(_ url: URL, lookingForCwd cwd: String) -> String? {
+        guard let data = try? Data(contentsOf: url),
+              let content = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+
+        // First line should be session_meta
+        guard let firstLine = content.split(separator: "\n").first,
+              let lineData = firstLine.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: lineData) as? [String: Any],
+              let type = json["type"] as? String,
+              type == "session_meta",
+              let payload = json["payload"] as? [String: Any],
+              let fileCwd = payload["cwd"] as? String,
+              let sessionId = payload["id"] as? String else {
+            return nil
+        }
+
+        // Check if cwd matches
+        if fileCwd == cwd {
+            return sessionId
+        }
+
+        return nil
+    }
+
+    /// Run a shell command and return output
+    private static func runCommand(_ executable: String, _ args: [String]) -> String {
+        let process = Process()
+        let pipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = Array(args)
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+            process.waitUntilExit()
+            let data = pipe.fileHandleForReading.readDataToEndOfFile()
+            return String(data: data, encoding: .utf8) ?? ""
+        } catch {
+            return ""
+        }
+    }
+}

--- a/Sources/CCStatusBarLib/Services/SessionObserver.swift
+++ b/Sources/CCStatusBarLib/Services/SessionObserver.swift
@@ -136,8 +136,9 @@ final class SessionObserver: ObservableObject {
     // MARK: - File Reading
 
     private func loadSessions() {
-        // Invalidate TmuxHelper cache when session file changes
+        // Invalidate TmuxHelper and CodexObserver caches when session file changes
         TmuxHelper.invalidatePaneInfoCache()
+        CodexObserver.invalidateCache()
 
         guard FileManager.default.fileExists(atPath: storeFile.path) else {
             sessions = []

--- a/Sources/CCStatusBarLib/Services/WebSocketManager.swift
+++ b/Sources/CCStatusBarLib/Services/WebSocketManager.swift
@@ -73,6 +73,7 @@ final class WebSocketManager {
     private let clientQueue = DispatchQueue(label: "com.ccstatusbar.websocket.clients")
 
     private var previousSessions: [String: Session] = [:]
+    private var previousCodexCwds = Set<String>()  // Track Codex sessions by cwd
     private var knownTerminalTypes = Set<String>()
     private var cancellables = Set<AnyCancellable>()
 
@@ -87,10 +88,14 @@ final class WebSocketManager {
         }
         DebugLog.log("[WebSocketManager] Client connected (total: \(connectedClients.count))")
 
-        // Send initial session list with icons
-        let sessions = SessionStore.shared.getSessions()
-        let sessionsData = sessions.map { sessionToDict($0) }
-        let icons = generateIcons(for: sessions)
+        // Send initial session list with icons (both Claude Code and Codex)
+        let claudeSessions = SessionStore.shared.getSessions()
+        let codexSessions = CodexObserver.getActiveSessions()
+
+        var sessionsData = claudeSessions.map { claudeSessionToDict($0) }
+        sessionsData += codexSessions.values.map { codexSessionToDict($0) }
+
+        let icons = generateIcons(claudeSessions: claudeSessions, codexSessions: Array(codexSessions.values))
         let event = WebSocketEvent(type: .sessionsList, sessions: sessionsData, icons: icons)
         sendToClient(session, event: event)
     }
@@ -138,6 +143,8 @@ final class WebSocketManager {
     private func handleSessionsChanged(_ sessions: [Session]) {
         let currentSessionsById = Dictionary(uniqueKeysWithValues: sessions.map { ($0.id, $0) })
 
+        // --- Claude Code sessions ---
+
         // Detect added sessions
         for session in sessions {
             if previousSessions[session.id] == nil {
@@ -152,7 +159,7 @@ final class WebSocketManager {
                     icon = IconManager.shared.iconBase64(for: env, size: 64)
                 }
 
-                let event = WebSocketEvent(type: .sessionAdded, session: sessionToDict(session), icon: icon)
+                let event = WebSocketEvent(type: .sessionAdded, session: claudeSessionToDict(session), icon: icon)
                 broadcast(event: event)
             }
         }
@@ -168,16 +175,46 @@ final class WebSocketManager {
         // Detect updated sessions
         for session in sessions {
             if let previous = previousSessions[session.id], session != previous {
-                let event = WebSocketEvent(type: .sessionUpdated, session: sessionToDict(session))
+                let event = WebSocketEvent(type: .sessionUpdated, session: claudeSessionToDict(session))
                 broadcast(event: event)
             }
         }
 
         previousSessions = currentSessionsById
+
+        // --- Codex sessions ---
+        let currentCodexSessions = CodexObserver.getActiveSessions()
+        let currentCodexCwds = Set(currentCodexSessions.keys)
+
+        // Detect added Codex sessions
+        for (cwd, codexSession) in currentCodexSessions {
+            if !previousCodexCwds.contains(cwd) {
+                let isNewType = !knownTerminalTypes.contains("Codex")
+                var icon: String? = nil
+                if isNewType {
+                    knownTerminalTypes.insert("Codex")
+                    // Codex doesn't have a specific icon yet, use nil
+                }
+                let event = WebSocketEvent(type: .sessionAdded, session: codexSessionToDict(codexSession), icon: icon)
+                broadcast(event: event)
+            }
+        }
+
+        // Detect removed Codex sessions
+        for cwd in previousCodexCwds {
+            if !currentCodexCwds.contains(cwd) {
+                let event = WebSocketEvent(type: .sessionRemoved, sessionId: "codex:\(cwd)")
+                broadcast(event: event)
+            }
+        }
+
+        previousCodexCwds = currentCodexCwds
     }
 
-    private func sessionToDict(_ session: Session) -> [String: Any] {
+    /// Convert Claude Code session to dictionary for WebSocket output
+    private func claudeSessionToDict(_ session: Session) -> [String: Any] {
         var dict: [String: Any] = [
+            "type": "claude_code",
             "id": session.id,
             "session_id": session.sessionId,
             "project": session.projectName,
@@ -212,29 +249,35 @@ final class WebSocketManager {
             ]
         }
 
-        // Add Codex info if available (matched by cwd)
-        if let codexInfo = CodexObserver.getCodexInfo(for: session.cwd) {
-            var codexDict: [String: Any] = [
-                "pid": codexInfo.pid,
-                "is_active": codexInfo.isActive
-            ]
-            if let startedAt = codexInfo.startedAt {
-                codexDict["started_at"] = ISO8601DateFormatter().string(from: startedAt)
-            }
-            if let sessionId = codexInfo.sessionId {
-                codexDict["session_id"] = sessionId
-            }
-            dict["codex"] = codexDict
+        return dict
+    }
+
+    /// Convert Codex session to dictionary for WebSocket output
+    private func codexSessionToDict(_ session: CodexSession) -> [String: Any] {
+        var dict: [String: Any] = [
+            "type": "codex",
+            "id": "codex:\(session.cwd)",
+            "pid": session.pid,
+            "project": session.projectName,
+            "cwd": session.cwd,
+            "status": "running",  // Codex is always running if detected
+            "started_at": ISO8601DateFormatter().string(from: session.startedAt),
+            "attention_level": 0  // Always green for running
+        ]
+
+        if let sessionId = session.sessionId {
+            dict["session_id"] = sessionId
         }
 
         return dict
     }
 
     /// Generate icons dictionary for all terminal types in sessions
-    private func generateIcons(for sessions: [Session]) -> [String: String] {
+    private func generateIcons(claudeSessions: [Session], codexSessions: [CodexSession]) -> [String: String] {
         var icons: [String: String] = [:]
 
-        for session in sessions {
+        // Claude Code session icons
+        for session in claudeSessions {
             let terminalName = session.environmentLabel
             if icons[terminalName] == nil {
                 let env = EnvironmentResolver.shared.resolve(session: session)
@@ -243,6 +286,12 @@ final class WebSocketManager {
                 }
                 knownTerminalTypes.insert(terminalName)
             }
+        }
+
+        // Codex icon (if any Codex sessions exist)
+        if !codexSessions.isEmpty && icons["Codex"] == nil {
+            // TODO: Add Codex icon when available
+            knownTerminalTypes.insert("Codex")
         }
 
         return icons

--- a/Sources/CCStatusBarLib/Services/WebSocketManager.swift
+++ b/Sources/CCStatusBarLib/Services/WebSocketManager.swift
@@ -189,13 +189,11 @@ final class WebSocketManager {
         // Detect added Codex sessions
         for (cwd, codexSession) in currentCodexSessions {
             if !previousCodexCwds.contains(cwd) {
-                let isNewType = !knownTerminalTypes.contains("Codex")
-                var icon: String? = nil
-                if isNewType {
+                if !knownTerminalTypes.contains("Codex") {
                     knownTerminalTypes.insert("Codex")
-                    // Codex doesn't have a specific icon yet, use nil
                 }
-                let event = WebSocketEvent(type: .sessionAdded, session: codexSessionToDict(codexSession), icon: icon)
+                // Codex doesn't have a specific icon yet (icon: nil)
+                let event = WebSocketEvent(type: .sessionAdded, session: codexSessionToDict(codexSession))
                 broadcast(event: event)
             }
         }
@@ -262,7 +260,8 @@ final class WebSocketManager {
             "cwd": session.cwd,
             "status": "running",  // Codex is always running if detected
             "started_at": ISO8601DateFormatter().string(from: session.startedAt),
-            "attention_level": 0  // Always green for running
+            "attention_level": 0,  // Always green for running
+            "terminal": "Codex"  // For icon lookup
         ]
 
         if let sessionId = session.sessionId {

--- a/Sources/CCStatusBarLib/Services/WebSocketManager.swift
+++ b/Sources/CCStatusBarLib/Services/WebSocketManager.swift
@@ -212,6 +212,21 @@ final class WebSocketManager {
             ]
         }
 
+        // Add Codex info if available (matched by cwd)
+        if let codexInfo = CodexObserver.getCodexInfo(for: session.cwd) {
+            var codexDict: [String: Any] = [
+                "pid": codexInfo.pid,
+                "is_active": codexInfo.isActive
+            ]
+            if let startedAt = codexInfo.startedAt {
+                codexDict["started_at"] = ISO8601DateFormatter().string(from: startedAt)
+            }
+            if let sessionId = codexInfo.sessionId {
+                codexDict["session_id"] = sessionId
+            }
+            dict["codex"] = codexDict
+        }
+
         return dict
     }
 


### PR DESCRIPTION
## Summary
- Add Codex CLI session tracking via WebSocket
- Refactor WebSocket output to independent session model
- Fix terminal field for Codex session icon lookup
- Render menu bar status as 2-row icon image (CC on top, count below)

## Changes
- `CodexSession.swift`: New model for Codex sessions
- `CodexObserver.swift`: Observe Codex CLI sessions
- `WebSocketManager.swift`: Independent session output for iOS app
- `AppDelegate.swift`: 2-row icon rendering instead of horizontal text

## Test plan
- [x] Build succeeds
- [x] Unit tests pass (35 tests)
- [x] Menu bar shows 2-row icon with correct colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)