### PR TITLE
feat: add configurable session display mode for tmux window/session name

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,18 @@ When triggered:
 2. If no waiting sessions, focuses the most recent session
 3. If no sessions, opens the menu
 
+### Session Display Mode
+Customize what is shown as the session name in the menu. Access via **Settings → Session Display**:
+
+| Mode | Display |
+|------|---------|
+| **Project Name** (default) | Directory name (e.g., `cc-status-bar`) |
+| **tmux Window Name** | Current tmux window name (e.g., `vim`) |
+| **tmux Session Name** | tmux session name (e.g., `main`) |
+| **tmux Session/Window** | Combined format (e.g., `main:vim`) |
+
+When not running in tmux, all modes fall back to Project Name.
+
 ### Notification Actions
 When a session needs attention, notifications include a **Focus Terminal** button for instant access.
 

--- a/Sources/CCStatusBarLib/Services/AppSettings.swift
+++ b/Sources/CCStatusBarLib/Services/AppSettings.swift
@@ -1,5 +1,22 @@
 import Foundation
 
+/// Session display mode for menu items
+enum SessionDisplayMode: String, CaseIterable {
+    case projectName = "project"              // Project name (default)
+    case tmuxWindow = "tmux_window"           // tmux window name
+    case tmuxSession = "tmux_session"         // tmux session name
+    case tmuxSessionWindow = "tmux_sess_win"  // tmux session:window format
+
+    var label: String {
+        switch self {
+        case .projectName: return "Project Name"
+        case .tmuxWindow: return "tmux Window Name"
+        case .tmuxSession: return "tmux Session Name"
+        case .tmuxSessionWindow: return "tmux Session/Window"
+        }
+    }
+}
+
 enum AppSettings {
     private enum Keys {
         static let launchAtLogin = "launchAtLogin"
@@ -8,6 +25,7 @@ enum AppSettings {
         static let webServerEnabled = "webServerEnabled"
         static let webServerPort = "webServerPort"
         static let colorTheme = "colorTheme"
+        static let sessionDisplayMode = "sessionDisplayMode"
     }
 
     /// Bundle ID for shared UserDefaults access (CLI and GUI)
@@ -74,5 +92,13 @@ enum AppSettings {
             return ColorTheme(rawValue: raw) ?? .vibrant
         }
         set { defaults.set(newValue.rawValue, forKey: Keys.colorTheme) }
+    }
+
+    static var sessionDisplayMode: SessionDisplayMode {
+        get {
+            let raw = defaults.string(forKey: Keys.sessionDisplayMode) ?? "project"
+            return SessionDisplayMode(rawValue: raw) ?? .projectName
+        }
+        set { defaults.set(newValue.rawValue, forKey: Keys.sessionDisplayMode) }
     }
 }

--- a/Sources/CCStatusBarLib/Views/SessionListView.swift
+++ b/Sources/CCStatusBarLib/Views/SessionListView.swift
@@ -56,6 +56,34 @@ struct SessionListView: View {
 struct SessionRowView: View {
     let session: Session
 
+    // Watch for sessionDisplayMode changes to trigger re-render
+    @AppStorage("sessionDisplayMode", store: UserDefaults(suiteName: "com.ccstatusbar.app"))
+    private var displayModeRaw: String = "project"
+
+    /// Computed display text based on sessionDisplayMode setting
+    private var displayText: String {
+        let mode = SessionDisplayMode(rawValue: displayModeRaw) ?? .projectName
+        switch mode {
+        case .projectName:
+            return session.displayName
+        case .tmuxWindow:
+            if let tty = session.tty, let paneInfo = TmuxHelper.getPaneInfo(for: tty) {
+                return paneInfo.windowName
+            }
+            return session.displayName  // Fallback
+        case .tmuxSession:
+            if let tty = session.tty, let paneInfo = TmuxHelper.getPaneInfo(for: tty) {
+                return paneInfo.session
+            }
+            return session.displayName  // Fallback
+        case .tmuxSessionWindow:
+            if let tty = session.tty, let paneInfo = TmuxHelper.getPaneInfo(for: tty) {
+                return "\(paneInfo.session):\(paneInfo.windowName)"
+            }
+            return session.displayName  // Fallback
+        }
+    }
+
     var body: some View {
         HStack(spacing: 8) {
             Text(session.status.symbol)
@@ -63,7 +91,7 @@ struct SessionRowView: View {
                 .frame(width: 16)
 
             VStack(alignment: .leading, spacing: 2) {
-                Text(session.displayName)
+                Text(displayText)
                     .font(.system(size: 12, weight: .medium))
                     .lineLimit(1)
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -828,3 +828,56 @@ ForEach(observer.sessions) { session in
 - **File**: `Sources/Views/SessionListWindow.swift`
 - **Class**: `SessionListWindowController`
 - **Struct**: `SessionListWindowView`, `PinnedSessionRowView`
+
+---
+
+## 22. Session Display Mode
+
+### 22.1 Purpose
+
+Allow users to customize what is displayed as the session name in menu items and pinned window. Useful for tmux users who want to see window or session names instead of project directory names.
+
+### 22.2 Display Modes
+
+| Mode | Raw Value | Display |
+|------|-----------|---------|
+| Project Name | `project` | Directory basename from `cwd` |
+| tmux Window Name | `tmux_window` | `#{window_name}` from tmux |
+| tmux Session Name | `tmux_session` | `#{session_name}` from tmux |
+| tmux Session/Window | `tmux_sess_win` | `session:window` format |
+
+### 22.3 Fallback Behavior
+
+When tmux information is unavailable (session not in tmux, or tmux command fails), all modes fall back to Project Name display.
+
+### 22.4 Storage
+
+- **Key**: `sessionDisplayMode`
+- **Default**: `project`
+- **Location**: UserDefaults suite `com.ccstatusbar.app`
+
+### 22.5 UI Integration
+
+Menu structure:
+```
+Settings ▶
+  └ Session Display ▶
+      ├ ✓ Project Name
+      ├   tmux Window Name
+      ├   tmux Session Name
+      └   tmux Session/Window
+```
+
+### 22.6 Implementation
+
+- **File**: `Sources/Services/AppSettings.swift`
+- **Enum**: `SessionDisplayMode`
+- **Property**: `AppSettings.sessionDisplayMode`
+- **File**: `Sources/Services/TmuxHelper.swift`
+- **Struct**: `PaneInfo` (extended with `windowName`)
+- **File**: `Sources/App/AppDelegate.swift`
+- **Method**: `createSessionMenuItem(_:)`, `createSessionDisplayMenu()`
+- **File**: `Sources/Views/SessionListView.swift`
+- **Computed Property**: `SessionRowView.displayText`
+- **File**: `Sources/Views/SessionListWindow.swift`
+- **Computed Property**: `PinnedSessionRowView.displayText`


### PR DESCRIPTION
## Summary
- Add settings to customize session menu item display text
- Options: Project Name (default), tmux Window Name, tmux Session Name, tmux Session/Window
- Instant update in both menu and pinned window via @AppStorage

## Changes
- Extend `PaneInfo` struct with `windowName` property
- Add `SessionDisplayMode` enum with 4 options
- Update menu item and pinned window views to use display mode setting
- Add "Session Display" submenu in Settings menu
- Use tab separator in tmux format string (handles window names with "|")
- Documentation: README.md and SPEC.md (Section 22)

## Test plan
- [x] Build and run the app
- [x] Open Settings > Session Display menu
- [x] Verify each display mode shows correct text in menu items
- [x] Verify pinned window (Pin as Window) also reflects the setting immediately
- [x] Test fallback behavior when not in tmux environment

🤖 Generated with [Claude Code](https://claude.ai/code)