### PR TITLE
fix: stabilize tmux/codex session detection and pin window behavior

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -16,8 +16,8 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Install TypeScript
-        run: npm install -g typescript
+      - name: Install Stream Deck Plugin dependencies
+        run: npm ci --prefix StreamDeckPlugin/com.ccstatusbar.sdPlugin
 
       - name: Run Tests
         run: ./scripts/test.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,7 +59,8 @@ jobs:
         run: |
           npm install -g @elgato/cli
           cd StreamDeckPlugin/com.ccstatusbar.sdPlugin
-          npx tsc src/plugin.ts --outDir bin --target ES2020 --module CommonJS --esModuleInterop
+          npm ci
+          npm run build
           cd ..
           streamdeck pack com.ccstatusbar.sdPlugin
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,19 @@ codesign --force --deep --sign - CCStatusBar.app
 open CCStatusBar.app
 ```
 
+### Build Dev App (CCStatusBarDev.app)
+Build a side-by-side development app with separate bundle ID (`com.ccstatusbar.dev`):
+
+```bash
+./scripts/build-dev-app.sh
+open CCStatusBarDev.app
+```
+
+This dev variant uses separate paths/settings from production:
+- `~/Library/Application Support/CCStatusBarDev`
+- UserDefaults suite: `com.ccstatusbar.dev`
+- Hook command name: `CCStatusBarDev`
+
 ### Stream Deck Plugin (Optional)
 
 If you have an Elgato Stream Deck, install the included plugin:

--- a/Sources/CCStatusBarLib/App/AppDelegate.swift
+++ b/Sources/CCStatusBarLib/App/AppDelegate.swift
@@ -754,7 +754,7 @@ public class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         let paneInfo: TmuxHelper.PaneInfo? = session.tty.flatMap { TmuxHelper.getPaneInfo(for: $0) }
 
         // Check if tmux session is detached
-        let isTmuxDetached = paneInfo.map { !TmuxHelper.isSessionAttached($0.session) } ?? false
+        let isTmuxDetached = paneInfo.map { !TmuxHelper.isSessionAttached($0.session, socketPath: $0.socketPath) } ?? false
 
         // Symbol color: gray for detached tmux, red for permission_prompt, yellow for stop/unknown, green for running/acknowledged
         let theme = AppSettings.colorTheme

--- a/Sources/CCStatusBarLib/App/AppDelegate.swift
+++ b/Sources/CCStatusBarLib/App/AppDelegate.swift
@@ -847,7 +847,7 @@ public class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     /// Get Codex sessions for menu display
     @MainActor
     private func getCodexSessionsForMenu() -> [CodexSession] {
-        return Array(CodexObserver.getActiveSessions().values)
+        return Array(CodexObserver.getActiveSessions().values).sorted { $0.pid < $1.pid }
     }
 
     /// Get Codex session counts for status title
@@ -1309,8 +1309,7 @@ public class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
 
     /// Update symlink to point to this executable
     private func updateSymlinkToSelf() {
-        let symlinkPath = NSString("~/Library/Application Support/CCStatusBar/bin/CCStatusBar")
-            .expandingTildeInPath
+        let symlinkPath = SetupManager.symlinkURL.path
         guard let executablePath = Bundle.main.executablePath else {
             DebugLog.log("[AppDelegate] Cannot get executable path for symlink update")
             return

--- a/Sources/CCStatusBarLib/CLI/SetupCommand.swift
+++ b/Sources/CCStatusBarLib/CLI/SetupCommand.swift
@@ -145,7 +145,7 @@ public struct SetupCommand: ParsableCommand {
                     }
                     return !innerHooks.contains { hook in
                         guard let command = hook["command"] as? String else { return false }
-                        return command.contains("CCStatusBar hook")
+                        return SetupManager.isOwnHookCommand(command)
                     }
                 }
                 eventHooks.append(entry)

--- a/Sources/CCStatusBarLib/Models/CodexSession.swift
+++ b/Sources/CCStatusBarLib/Models/CodexSession.swift
@@ -22,6 +22,9 @@ struct CodexSession: Equatable {
     /// tmux pane index
     var tmuxPane: String?
 
+    /// tmux socket path (for non-default servers)
+    var tmuxSocketPath: String?
+
     /// Terminal app name (e.g., "ghostty", "iTerm.app")
     var terminalApp: String?
 

--- a/Sources/CCStatusBarLib/Models/CodexSession.swift
+++ b/Sources/CCStatusBarLib/Models/CodexSession.swift
@@ -42,7 +42,7 @@ struct CodexSession: Equatable {
 }
 
 extension CodexSession: Identifiable {
-    var id: String { cwd }
+    var id: String { "codex:\(pid)" }
 
     /// Display text based on session display mode setting
     func displayText(for mode: SessionDisplayMode) -> String {

--- a/Sources/CCStatusBarLib/Services/AppSettings.swift
+++ b/Sources/CCStatusBarLib/Services/AppSettings.swift
@@ -39,6 +39,11 @@ enum AppSettings {
         UserDefaults(suiteName: bundleID) ?? UserDefaults.standard
     }
 
+    /// Shared UserDefaults store (for @AppStorage)
+    static var userDefaultsStore: UserDefaults {
+        defaults
+    }
+
     static var launchAtLogin: Bool {
         get { defaults.bool(forKey: Keys.launchAtLogin) }
         set { defaults.set(newValue, forKey: Keys.launchAtLogin) }

--- a/Sources/CCStatusBarLib/Services/CodexObserver.swift
+++ b/Sources/CCStatusBarLib/Services/CodexObserver.swift
@@ -96,6 +96,7 @@ enum CodexObserver {
                         session.tmuxSession = paneInfo.session
                         session.tmuxWindow = paneInfo.window
                         session.tmuxPane = paneInfo.pane
+                        session.tmuxSocketPath = paneInfo.socketPath
                         DebugLog.log("[CodexObserver] Found tmux pane for Codex PID \(pid): \(paneInfo.session):\(paneInfo.window).\(paneInfo.pane)")
 
                         // Detect terminal app from tmux client

--- a/Sources/CCStatusBarLib/Services/CodexObserver.swift
+++ b/Sources/CCStatusBarLib/Services/CodexObserver.swift
@@ -18,8 +18,8 @@ enum CodexObserver {
 
     // MARK: - Public API
 
-    /// Get all active Codex sessions indexed by cwd
-    /// - Returns: Dictionary of cwd -> CodexSession
+    /// Get all active Codex sessions indexed by internal id
+    /// - Returns: Dictionary of session key -> CodexSession
     static func getActiveSessions() -> [String: CodexSession] {
         let now = Date()
 
@@ -44,14 +44,17 @@ enum CodexObserver {
     /// - Parameter cwd: The working directory to check
     /// - Returns: true if Codex is running in that directory
     static func isCodexRunning(for cwd: String) -> Bool {
-        return getActiveSessions()[cwd] != nil
+        return getActiveSessions().values.contains { $0.cwd == cwd }
     }
 
     /// Get Codex session for a specific cwd
     /// - Parameter cwd: The working directory
     /// - Returns: CodexSession if running, nil otherwise
     static func getCodexSession(for cwd: String) -> CodexSession? {
-        return getActiveSessions()[cwd]
+        return getActiveSessions().values
+            .filter { $0.cwd == cwd }
+            .sorted { $0.pid < $1.pid }
+            .first
     }
 
     /// Get CodexInfo for WebSocket output
@@ -103,7 +106,8 @@ enum CodexObserver {
                     }
                 }
 
-                sessions[cwd] = session
+                let key = "codex:\(pid)"
+                sessions[key] = session
                 DebugLog.log("[CodexObserver] Found Codex PID \(pid) in \(session.projectName)")
             }
         }
@@ -129,12 +133,30 @@ enum CodexObserver {
 
     /// Get PIDs of running Codex processes
     private static func getCodexPIDs() -> [pid_t] {
-        // pgrep for codex vendor processes
-        let output = runCommand("/usr/bin/pgrep", ["-f", "codex/vendor.*codex"])
-        let pids = output
-            .split(separator: "\n")
-            .compactMap { pid_t($0.trimmingCharacters(in: .whitespaces)) }
-        return pids
+        var pidSet = Set<pid_t>()
+
+        // Current Codex CLI typically runs as a direct executable named "codex"
+        // (or occasionally "codex-cli"), so prioritize exact process-name matches.
+        for processName in ["codex", "codex-cli"] {
+            let output = runCommand("/usr/bin/pgrep", ["-x", processName])
+            for line in output.split(separator: "\n") {
+                if let pid = pid_t(line.trimmingCharacters(in: .whitespaces)) {
+                    pidSet.insert(pid)
+                }
+            }
+        }
+
+        // Backward compatibility: legacy Node/vendor launch patterns.
+        for pattern in ["codex/vendor.*codex", "@openai/codex"] {
+            let output = runCommand("/usr/bin/pgrep", ["-f", pattern])
+            for line in output.split(separator: "\n") {
+                if let pid = pid_t(line.trimmingCharacters(in: .whitespaces)) {
+                    pidSet.insert(pid)
+                }
+            }
+        }
+
+        return Array(pidSet).sorted()
     }
 
     /// Get current working directory for a process

--- a/Sources/CCStatusBarLib/Services/DebugLog.swift
+++ b/Sources/CCStatusBarLib/Services/DebugLog.swift
@@ -115,7 +115,8 @@ enum DebugLog {
                 return arr.contains { entry in
                     guard let innerHooks = entry["hooks"] as? [[String: Any]] else { return false }
                     return innerHooks.contains { hook in
-                        (hook["command"] as? String)?.contains("CCStatusBar") == true
+                        guard let command = hook["command"] as? String else { return false }
+                        return SetupManager.isOwnHookCommand(command)
                     }
                 }
             }

--- a/Sources/CCStatusBarLib/Services/DiagnosticsManager.swift
+++ b/Sources/CCStatusBarLib/Services/DiagnosticsManager.swift
@@ -85,8 +85,10 @@ enum DiagnosticIssue: Identifiable {
             Session tracking won't work without hooks.
             """
         case .sessionsFileIssue(let reason):
+            let expected = SetupManager.sessionsFile.path
+                .replacingOccurrences(of: FileManager.default.homeDirectoryForCurrentUser.path, with: "~")
             return """
-            Expected: ~/Library/Application Support/CCStatusBar/sessions.json
+            Expected: \(expected)
             Status: \(reason)
             """
         }
@@ -133,11 +135,15 @@ enum DiagnosticIssue: Identifiable {
             See README.md for complete configuration.
             """
         case .sessionsFileIssue:
+            let appSupportDir = SetupManager.appSupportDir.path
+                .replacingOccurrences(of: " ", with: "\\ ")
+            let sessionsPath = SetupManager.sessionsFile.path
+                .replacingOccurrences(of: " ", with: "\\ ")
             return """
             1. Restart the app (file will be created automatically)
             2. If that doesn't work:
-               mkdir -p ~/Library/Application\\ Support/CCStatusBar
-               echo '{"sessions":{}}' > ~/Library/Application\\ Support/CCStatusBar/sessions.json
+               mkdir -p \(appSupportDir)
+               echo '{"sessions":{}}' > \(sessionsPath)
             """
         }
     }

--- a/Sources/CCStatusBarLib/Services/DiagnosticsManager.swift
+++ b/Sources/CCStatusBarLib/Services/DiagnosticsManager.swift
@@ -327,7 +327,7 @@ final class DiagnosticsManager: ObservableObject {
                         if let hookList = hook["hooks"] as? [[String: Any]] {
                             for h in hookList {
                                 if let command = h["command"] as? String,
-                                   command.contains("CCStatusBar") {
+                                   command.contains("CCStatusBar hook") {
                                     hasAnyHook = true
                                     break
                                 }

--- a/Sources/CCStatusBarLib/Services/DiagnosticsManager.swift
+++ b/Sources/CCStatusBarLib/Services/DiagnosticsManager.swift
@@ -327,7 +327,7 @@ final class DiagnosticsManager: ObservableObject {
                         if let hookList = hook["hooks"] as? [[String: Any]] {
                             for h in hookList {
                                 if let command = h["command"] as? String,
-                                   command.contains("CCStatusBar hook") {
+                                   SetupManager.isOwnHookCommand(command) {
                                     hasAnyHook = true
                                     break
                                 }

--- a/Sources/CCStatusBarLib/Services/GhosttyHelper.swift
+++ b/Sources/CCStatusBarLib/Services/GhosttyHelper.swift
@@ -131,26 +131,12 @@ enum GhosttyHelper {
         return false
     }
 
-    /// Check if accessibility permission is granted
-    static func checkAccessibilityPermission() -> Bool {
-        let checkOptPrompt = kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String
-        let options = [checkOptPrompt: false] as CFDictionary
-        return AXIsProcessTrustedWithOptions(options)
-    }
-
-    /// Request accessibility permission (shows system dialog)
-    static func requestAccessibilityPermission() {
-        let checkOptPrompt = kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String
-        let options = [checkOptPrompt: true] as CFDictionary
-        AXIsProcessTrustedWithOptions(options)
-    }
-
     /// Find and click a tab by its title using Accessibility API
     private static func focusTabByTitle(_ targetTitle: String, pid: pid_t) -> Bool {
         // Check accessibility permission first
-        if !checkAccessibilityPermission() {
+        if !PermissionManager.checkAccessibilityPermission() {
             DebugLog.log("[GhosttyHelper] Accessibility permission not granted")
-            requestAccessibilityPermission()
+            PermissionManager.requestAccessibilityPermissionOncePerLaunch()
             return false
         }
 

--- a/Sources/CCStatusBarLib/Services/SessionObserver.swift
+++ b/Sources/CCStatusBarLib/Services/SessionObserver.swift
@@ -140,7 +140,7 @@ final class SessionObserver: ObservableObject {
         // Invalidate TmuxHelper and CodexObserver caches when session file changes
         TmuxHelper.invalidatePaneInfoCache()
         CodexObserver.invalidateCache()
-        self.codexSessions = Array(CodexObserver.getActiveSessions().values)
+        self.codexSessions = Array(CodexObserver.getActiveSessions().values).sorted { $0.pid < $1.pid }
 
         guard FileManager.default.fileExists(atPath: storeFile.path) else {
             sessions = []

--- a/Sources/CCStatusBarLib/Services/SetupManager.swift
+++ b/Sources/CCStatusBarLib/Services/SetupManager.swift
@@ -56,9 +56,24 @@ final class SetupManager {
 
     private init() {}
 
-    private static func isOwnHookCommand(_ command: String) -> Bool {
-        command.contains("CCStatusBar hook")
+    /// Check whether a command string is one of CCStatusBar's hook commands.
+    /// Supports quoted paths with spaces, e.g. "\".../CCStatusBar\" hook Notification".
+    static func isOwnHookCommand(_ command: String) -> Bool {
+        let normalized = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalized.isEmpty else { return false }
+        let range = NSRange(normalized.startIndex..<normalized.endIndex, in: normalized)
+        return ownHookCommandRegex.firstMatch(in: normalized, options: [], range: range) != nil
     }
+
+    private static let ownHookCommandRegex: NSRegularExpression = {
+        // Match /CCStatusBar[optional quote] <space> hook <space or end>
+        // Examples:
+        // - "/Users/.../CCStatusBar" hook Notification
+        // - /usr/local/bin/CCStatusBar hook Stop
+        // - CCStatusBar hook Notification
+        let pattern = #"(?:^|/)CCStatusBar(?:["'])?\s+hook(?:\s+|$)"#
+        return try! NSRegularExpression(pattern: pattern)
+    }()
 
     // MARK: - Public API
 

--- a/Sources/CCStatusBarLib/Services/SetupManager.swift
+++ b/Sources/CCStatusBarLib/Services/SetupManager.swift
@@ -56,6 +56,10 @@ final class SetupManager {
 
     private init() {}
 
+    private static func isOwnHookCommand(_ command: String) -> Bool {
+        command.contains("CCStatusBar hook")
+    }
+
     // MARK: - Public API
 
     /// Run setup wizard. Use force=true to reconfigure even if already set up.
@@ -164,7 +168,7 @@ final class SetupManager {
                         if let innerHooks = hookEntry["hooks"] as? [[String: Any]] {
                             for hook in innerHooks {
                                 if let command = hook["command"] as? String,
-                                   command.contains("CCStatusBar hook") {
+                                   Self.isOwnHookCommand(command) {
                                     return false // Found our hook
                                 }
                             }
@@ -315,7 +319,7 @@ final class SetupManager {
                     // Remove any existing CCStatusBar hooks from this entry
                     innerHooks = innerHooks.filter { hook in
                         guard let command = hook["command"] as? String else { return true }
-                        if command.contains("CCStatusBar") {
+                        if Self.isOwnHookCommand(command) {
                             hadExistingCCStatusBarHook = true
                             return false
                         }
@@ -560,7 +564,7 @@ final class SetupManager {
                     }
                     return !innerHooks.contains { hook in
                         guard let command = hook["command"] as? String else { return false }
-                        return command.contains("CCStatusBar hook")
+                        return Self.isOwnHookCommand(command)
                     }
                 }
                 if filtered.isEmpty {

--- a/Sources/CCStatusBarLib/Services/TmuxHelper.swift
+++ b/Sources/CCStatusBarLib/Services/TmuxHelper.swift
@@ -349,7 +349,7 @@ enum TmuxHelper {
     }
 
     private static func parsePaneInfo(from output: String, matchingTTY tty: String, socketPath: String?) -> PaneInfo? {
-        for line in output.split(separator: "\n") {
+        for line in output.split(separator: "\n", omittingEmptySubsequences: false) {
             let parts = line.split(separator: "\t", omittingEmptySubsequences: false).map(String.init)
             guard parts.count >= 5 else { continue }
             if normalizeTTY(parts[0]) == tty {

--- a/Sources/CCStatusBarLib/Services/WebSocketManager.swift
+++ b/Sources/CCStatusBarLib/Services/WebSocketManager.swift
@@ -80,7 +80,7 @@ final class WebSocketManager {
     private let clientQueue = DispatchQueue(label: "com.ccstatusbar.websocket.clients")
 
     private var previousSessions: [String: Session] = [:]
-    private var previousCodexCwds = Set<String>()  // Track Codex sessions by cwd
+    private var previousCodexIDs = Set<String>()  // Track Codex sessions by unique id
     private var knownTerminalTypes = Set<String>()
     private var cancellables = Set<AnyCancellable>()
 
@@ -104,11 +104,12 @@ final class WebSocketManager {
         // Send initial session list with icons (both Claude Code and Codex)
         let claudeSessions = SessionStore.shared.getSessions()
         let codexSessions = CodexObserver.getActiveSessions()
+        let codexSessionList = Array(codexSessions.values).sorted { $0.pid < $1.pid }
 
         var sessionsData = claudeSessions.map { claudeSessionToDict($0) }
-        sessionsData += codexSessions.values.map { codexSessionToDict($0) }
+        sessionsData += codexSessionList.map { codexSessionToDict($0) }
 
-        let icons = generateIcons(claudeSessions: claudeSessions, codexSessions: Array(codexSessions.values))
+        let icons = generateIcons(claudeSessions: claudeSessions, codexSessions: codexSessionList)
         let event = WebSocketEvent(type: .sessionsList, sessions: sessionsData, icons: icons)
         sendToClient(session, event: event)
     }
@@ -197,11 +198,11 @@ final class WebSocketManager {
 
         // --- Codex sessions ---
         let currentCodexSessions = CodexObserver.getActiveSessions()
-        let currentCodexCwds = Set(currentCodexSessions.keys)
+        let currentCodexIDs = Set(currentCodexSessions.keys)
 
         // Detect added Codex sessions
-        for (cwd, codexSession) in currentCodexSessions {
-            if !previousCodexCwds.contains(cwd) {
+        for (id, codexSession) in currentCodexSessions {
+            if !previousCodexIDs.contains(id) {
                 // Check if this is a new terminal type
                 let terminalName = codexSession.terminalApp ?? "Codex"
                 let isNewTerminalType = !knownTerminalTypes.contains(terminalName)
@@ -221,14 +222,14 @@ final class WebSocketManager {
         }
 
         // Detect removed Codex sessions
-        for cwd in previousCodexCwds {
-            if !currentCodexCwds.contains(cwd) {
-                let event = WebSocketEvent(type: .sessionRemoved, sessionId: "codex:\(cwd)")
+        for id in previousCodexIDs {
+            if !currentCodexIDs.contains(id) {
+                let event = WebSocketEvent(type: .sessionRemoved, sessionId: id)
                 broadcast(event: event)
             }
         }
 
-        previousCodexCwds = currentCodexCwds
+        previousCodexIDs = currentCodexIDs
     }
 
     /// Convert Claude Code session to dictionary for WebSocket output
@@ -284,7 +285,7 @@ final class WebSocketManager {
 
         var dict: [String: Any] = [
             "type": "codex",
-            "id": "codex:\(session.cwd)",
+            "id": "codex:\(session.pid)",
             "pid": session.pid,
             "project": session.projectName,
             "cwd": session.cwd,

--- a/Sources/CCStatusBarLib/Services/WebSocketManager.swift
+++ b/Sources/CCStatusBarLib/Services/WebSocketManager.swift
@@ -278,7 +278,13 @@ final class WebSocketManager {
     func codexSessionToDict(_ session: CodexSession) -> [String: Any] {
         // Get status from CodexStatusReceiver
         let status = CodexStatusReceiver.shared.getStatus(for: session.cwd)
-        let attentionLevel = status == .waitingInput ? 1 : 0  // yellow or green
+        let waitingReason = CodexStatusReceiver.shared.getWaitingReason(for: session.cwd)
+        let attentionLevel: Int
+        if status == .waitingInput {
+            attentionLevel = (waitingReason == .permissionPrompt) ? 2 : 1  // red or yellow
+        } else {
+            attentionLevel = 0
+        }
 
         // Use detected terminal app, or fallback to "Codex"
         let terminalName = session.terminalApp ?? "Codex"
@@ -297,6 +303,10 @@ final class WebSocketManager {
 
         if let sessionId = session.sessionId {
             dict["session_id"] = sessionId
+        }
+
+        if status == .waitingInput {
+            dict["waiting_reason"] = (waitingReason ?? .unknown).rawValue
         }
 
         // Add TTY if available

--- a/Sources/CCStatusBarLib/Services/WebSocketManager.swift
+++ b/Sources/CCStatusBarLib/Services/WebSocketManager.swift
@@ -266,7 +266,7 @@ final class WebSocketManager {
                 "window": remoteInfo.windowIndex,
                 "pane": remoteInfo.paneIndex,
                 "attach_command": remoteInfo.attachCommand,
-                "is_attached": TmuxHelper.isSessionAttached(remoteInfo.sessionName)
+                "is_attached": TmuxHelper.isSessionAttached(remoteInfo.sessionName, socketPath: remoteInfo.socketPath)
             ]
         }
 
@@ -313,7 +313,7 @@ final class WebSocketManager {
                 "window": tmuxWindow,
                 "pane": tmuxPane,
                 "attach_command": "tmux attach -t \(tmuxSession):\(tmuxWindow).\(tmuxPane)",
-                "is_attached": TmuxHelper.isSessionAttached(tmuxSession)
+                "is_attached": TmuxHelper.isSessionAttached(tmuxSession, socketPath: session.tmuxSocketPath)
             ]
         }
 

--- a/Sources/CCStatusBarLib/Views/SessionListView.swift
+++ b/Sources/CCStatusBarLib/Views/SessionListView.swift
@@ -57,7 +57,7 @@ struct SessionRowView: View {
     let session: Session
 
     // Watch for sessionDisplayMode changes to trigger re-render
-    @AppStorage("sessionDisplayMode", store: UserDefaults(suiteName: "com.ccstatusbar.app"))
+    @AppStorage("sessionDisplayMode", store: AppSettings.userDefaultsStore)
     private var displayModeRaw: String = "project"
 
     /// Computed display text based on sessionDisplayMode setting

--- a/Sources/CCStatusBarLib/Views/SessionListWindow.swift
+++ b/Sources/CCStatusBarLib/Views/SessionListWindow.swift
@@ -570,6 +570,12 @@ struct PinnedCodexSessionRowView: View {
         CodexStatusReceiver.shared.getStatus(for: codexSession.cwd)
     }
 
+    private var waitingReason: CodexWaitingReason? {
+        status == .waitingInput
+            ? CodexStatusReceiver.shared.getWaitingReason(for: codexSession.cwd)
+            : nil
+    }
+
     var body: some View {
         HStack(spacing: 8) {
             // Terminal icon with badge
@@ -683,13 +689,20 @@ struct PinnedCodexSessionRowView: View {
     }
 
     private var statusLabel: String {
-        status == .waitingInput ? "Waiting" : "Running"
+        if status == .waitingInput {
+            return waitingReason == .permissionPrompt ? "Permission" : "Waiting"
+        }
+        return "Running"
     }
 
     private var statusColor: Color {
-        status == .waitingInput
-            ? Color(red: 1.0, green: 0.7, blue: 0.2)
-            : Color(red: 0.3, green: 0.85, blue: 0.4)
+        if status == .waitingInput {
+            if waitingReason == .permissionPrompt {
+                return Color(red: 1.0, green: 0.3, blue: 0.3)
+            }
+            return Color(red: 1.0, green: 0.7, blue: 0.2)
+        }
+        return Color(red: 0.3, green: 0.85, blue: 0.4)
     }
 
     private func focusCodexSession() {

--- a/Sources/CCStatusBarLib/Views/SessionListWindow.swift
+++ b/Sources/CCStatusBarLib/Views/SessionListWindow.swift
@@ -181,8 +181,10 @@ final class SessionListWindowController {
 struct SessionListWindowView: View {
     @ObservedObject var observer: SessionObserver
     @State private var dragStartHeight: CGFloat = 0
-    @State private var showCC = AppSettings.showClaudeCodeSessions
-    @State private var showCodex = AppSettings.showCodexSessions
+    @AppStorage("showClaudeCodeSessions", store: AppSettings.userDefaultsStore)
+    private var showCC: Bool = true
+    @AppStorage("showCodexSessions", store: AppSettings.userDefaultsStore)
+    private var showCodex: Bool = true
 
     private var filteredCCSessions: [Session] {
         showCC ? observer.sessions : []
@@ -205,11 +207,9 @@ struct SessionListWindowView: View {
                     HStack(spacing: 8) {
                         FilterToggleButton(label: "CC", isOn: showCC) {
                             showCC.toggle()
-                            AppSettings.showClaudeCodeSessions = showCC
                         }
                         FilterToggleButton(label: "Codex", isOn: showCodex) {
                             showCodex.toggle()
-                            AppSettings.showCodexSessions = showCodex
                         }
                         Spacer()
                     }
@@ -339,7 +339,7 @@ struct PinnedSessionRowView: View {
     @State private var isPressed = false
 
     // Watch for sessionDisplayMode changes to trigger re-render
-    @AppStorage("sessionDisplayMode", store: UserDefaults(suiteName: "com.ccstatusbar.app"))
+    @AppStorage("sessionDisplayMode", store: AppSettings.userDefaultsStore)
     private var displayModeRaw: String = "project"
 
     private var env: FocusEnvironment {
@@ -506,7 +506,7 @@ struct PinnedCodexSessionRowView: View {
     @State private var isPressed = false
 
     // Watch for sessionDisplayMode changes to trigger re-render
-    @AppStorage("sessionDisplayMode", store: UserDefaults(suiteName: "com.ccstatusbar.app"))
+    @AppStorage("sessionDisplayMode", store: AppSettings.userDefaultsStore)
     private var displayModeRaw: String = "project"
 
     /// Computed display text based on sessionDisplayMode setting

--- a/StreamDeckPlugin/com.ccstatusbar.sdPlugin/src/plugin.ts
+++ b/StreamDeckPlugin/com.ccstatusbar.sdPlugin/src/plugin.ts
@@ -6,7 +6,7 @@
  */
 
 import WebSocket from 'ws';
-import { execSync, exec } from 'child_process';
+import { execSync, exec, ExecException } from 'child_process';
 import { appendFileSync } from 'fs';
 import path from 'path';
 
@@ -331,7 +331,7 @@ function handleKeyDown(action: string, context: string): void {
  * Handle escape key
  */
 function handleEscape(): void {
-    exec(`osascript -e 'tell application "System Events" to key code 53'`, (error) => {
+    exec(`osascript -e 'tell application "System Events" to key code 53'`, (error: ExecException | null) => {
         if (error) {
             console.error('Escape key error:', error.message);
         }
@@ -342,7 +342,7 @@ function handleEscape(): void {
  * Handle Shift+Tab key (toggle plan mode)
  */
 function handleShiftTab(): void {
-    exec(`osascript -e 'tell application "System Events" to key code 48 using shift down'`, (error) => {
+    exec(`osascript -e 'tell application "System Events" to key code 48 using shift down'`, (error: ExecException | null) => {
         if (error) {
             console.error('Shift+Tab error:', error.message);
         }
@@ -355,7 +355,7 @@ function handleShiftTab(): void {
  */
 function handleFocusWaiting(): void {
     // Simulate the global hotkey (Cmd+Ctrl+C) to use app's unified logic
-    exec(`osascript -e 'tell application "System Events" to key code 8 using {command down, control down}'`, (error) => {
+    exec(`osascript -e 'tell application "System Events" to key code 8 using {command down, control down}'`, (error: ExecException | null) => {
         if (error) console.error('Hotkey simulation error:', error.message);
     });
 }
@@ -392,7 +392,7 @@ function handleSessionClick(context: string): void {
  * Handle up arrow key
  */
 function handleScrollUp(): void {
-    exec(`osascript -e 'tell application "System Events" to key code 126'`, (error) => {
+    exec(`osascript -e 'tell application "System Events" to key code 126'`, (error: ExecException | null) => {
         if (error) {
             console.error('Up arrow key error:', error.message);
         }
@@ -403,7 +403,7 @@ function handleScrollUp(): void {
  * Handle down arrow key
  */
 function handleScrollDown(): void {
-    exec(`osascript -e 'tell application "System Events" to key code 125'`, (error) => {
+    exec(`osascript -e 'tell application "System Events" to key code 125'`, (error: ExecException | null) => {
         if (error) {
             console.error('Down arrow key error:', error.message);
         }
@@ -415,7 +415,7 @@ function handleScrollDown(): void {
  */
 function handleDictation(): void {
     // Use CCStatusBar CLI which handles CGEvent double-Fn tap with AppleScript fallback
-    exec(`"${CLI_PATH}" dictation`, (error) => {
+    exec(`"${CLI_PATH}" dictation`, (error: ExecException | null) => {
         if (error) {
             console.error('Dictation error:', error.message);
         }
@@ -426,7 +426,7 @@ function handleDictation(): void {
  * Handle enter key
  */
 function handleEnter(): void {
-    exec(`osascript -e 'tell application "System Events" to key code 36'`, (error) => {
+    exec(`osascript -e 'tell application "System Events" to key code 36'`, (error: ExecException | null) => {
         if (error) {
             console.error('Enter key error:', error.message);
         }

--- a/StreamDeckPlugin/com.ccstatusbar.sdPlugin/tsconfig.json
+++ b/StreamDeckPlugin/com.ccstatusbar.sdPlugin/tsconfig.json
@@ -2,10 +2,12 @@
   "compilerOptions": {
     "target": "ES2020",
     "module": "CommonJS",
+    "moduleResolution": "node",
     "outDir": "./bin",
     "rootDir": "./src",
     "strict": true,
     "esModuleInterop": true,
+    "types": ["node"],
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,

--- a/Tests/CodexObserverTests.swift
+++ b/Tests/CodexObserverTests.swift
@@ -1,0 +1,16 @@
+import XCTest
+@testable import CCStatusBarLib
+
+final class CodexObserverTests: XCTestCase {
+    func testShouldTrackCodexCommandLineForInteractiveCodex() {
+        XCTAssertTrue(CodexObserver.shouldTrackCodexCommandLine("codex"))
+        XCTAssertTrue(CodexObserver.shouldTrackCodexCommandLine("codex --model gpt-5"))
+        XCTAssertTrue(CodexObserver.shouldTrackCodexCommandLine("/opt/homebrew/bin/codex --ask"))
+    }
+
+    func testShouldNotTrackCodexMCPServerCommandLine() {
+        XCTAssertFalse(CodexObserver.shouldTrackCodexCommandLine("codex mcp-server"))
+        XCTAssertFalse(CodexObserver.shouldTrackCodexCommandLine("codex mcp-server --stdio"))
+        XCTAssertFalse(CodexObserver.shouldTrackCodexCommandLine("/opt/homebrew/bin/codex mcp-server --stdio"))
+    }
+}

--- a/Tests/CodexStatusReceiverTests.swift
+++ b/Tests/CodexStatusReceiverTests.swift
@@ -1,0 +1,33 @@
+import XCTest
+@testable import CCStatusBarLib
+
+final class CodexStatusReceiverTests: XCTestCase {
+    @MainActor
+    func testInferWaitingReasonDefaultsToStop() {
+        let reason = CodexStatusReceiver.inferWaitingReason(from: [
+            "type": "agent-turn-complete",
+            "cwd": "/tmp/project"
+        ])
+        XCTAssertEqual(reason, .stop)
+    }
+
+    @MainActor
+    func testInferWaitingReasonDetectsPermissionPrompt() {
+        let reason = CodexStatusReceiver.inferWaitingReason(from: [
+            "type": "agent-turn-complete",
+            "notification_type": "permission_prompt"
+        ])
+        XCTAssertEqual(reason, .permissionPrompt)
+    }
+
+    @MainActor
+    func testInferWaitingReasonDetectsApprovalTokensInNestedPayload() {
+        let reason = CodexStatusReceiver.inferWaitingReason(from: [
+            "type": "agent-turn-complete",
+            "payload": [
+                "reason": "approval_required"
+            ]
+        ])
+        XCTAssertEqual(reason, .permissionPrompt)
+    }
+}

--- a/Tests/SetupManagerHookCommandTests.swift
+++ b/Tests/SetupManagerHookCommandTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+@testable import CCStatusBarLib
+
+final class SetupManagerHookCommandTests: XCTestCase {
+    func testOwnHookCommandMatchesQuotedPathWithSpaces() {
+        let command = "\"/Users/test/Library/Application Support/CCStatusBar/bin/CCStatusBar\" hook Notification"
+        XCTAssertTrue(SetupManager.isOwnHookCommand(command))
+    }
+
+    func testOwnHookCommandMatchesUnquotedPath() {
+        let command = "/usr/local/bin/CCStatusBar hook Stop"
+        XCTAssertTrue(SetupManager.isOwnHookCommand(command))
+    }
+
+    func testOwnHookCommandRejectsNonHookCommand() {
+        let command = "\"/Users/test/Library/Application Support/CCStatusBar/bin/CCStatusBar\" setup"
+        XCTAssertFalse(SetupManager.isOwnHookCommand(command))
+    }
+
+    func testOwnHookCommandRejectsDevBinaryCommand() {
+        let command = "\"/Users/test/Library/Application Support/CCStatusBarDev/bin/CCStatusBarDev\" hook Notification"
+        XCTAssertFalse(SetupManager.isOwnHookCommand(command))
+    }
+}


### PR DESCRIPTION
## 概要
このブランチでは、`tmux` / `Codex` セッション検出の安定化、`Pin as Window` の表示整合性改善、`Codex` の待機状態（赤/黄）の判定導入、Hook/診断/CI の不具合修正を行いました。

## 変更内容
- `tmux` の pane/session 解析を強化し、ウィンドウ名欠落や取りこぼしを低減
- attach 判定を socket-aware 化し、同名セッションのソケット跨ぎ混線を解消
- `CodexObserver` で `codex mcp-server` など非対話サブプロセスを除外
- `Codex` の waiting 状態に対して red/yellow 判定（`permission_prompt` / それ以外）を導入
- メニューバー / Pin as Window / WebSocket 出力の状態表示ロジックを整合
- Hook コマンド（quoted path 含む）の検出精度を改善
- Stream Deck plugin の TypeScript チェックを CI で安定化
- Accessibility 許可ダイアログの連続表示を抑制（起動中1回）

## 動作確認
- `swift test`（44 tests passed）
- `swift build`
