### PR TITLE
fix: show real status for acknowledged waiting sessions

### DIFF
--- a/Sources/CCStatusBarLib/App/AppDelegate.swift
+++ b/Sources/CCStatusBarLib/App/AppDelegate.swift
@@ -887,9 +887,6 @@ $CCSB_TMUX_PANE_TARGET
 
         // Check if session is acknowledged (for display purposes)
         let isAcknowledged = sessionObserver.isAcknowledged(sessionId: session.id)
-        let displayStatus: SessionStatus = (isAcknowledged && session.status == .waitingInput)
-            ? .running  // Show as green if acknowledged
-            : session.status
 
         // Get pane info once and reuse for both isTmuxDetached and displayText
         let paneInfo: TmuxHelper.PaneInfo? = session.tty.flatMap { TmuxHelper.getPaneInfo(for: $0) }
@@ -897,23 +894,25 @@ $CCSB_TMUX_PANE_TARGET
         // Check if tmux session is detached
         let isTmuxDetached = paneInfo.map { !TmuxHelper.isSessionAttached($0.session, socketPath: $0.socketPath) } ?? false
 
-        // Symbol color: gray for detached tmux, red for permission_prompt, yellow for stop/unknown, green for running/acknowledged
+        // Symbol color: gray for detached tmux, muted for acknowledged waiting, bright for unacknowledged waiting
         let theme = AppSettings.colorTheme
         let symbolColor: NSColor
         if isTmuxDetached {
-            symbolColor = .tertiaryLabelColor  // Grayed out for detached tmux
-        } else if !isAcknowledged && session.status == .waitingInput {
-            // Unacknowledged waiting: red for permission_prompt, yellow otherwise
-            symbolColor = (session.waitingReason == .permissionPrompt) ? theme.redColor : theme.yellowColor
-        } else {
-            switch displayStatus {
-            case .running:
-                symbolColor = theme.greenColor
-            case .waitingInput:
-                symbolColor = theme.yellowColor  // Fallback (shouldn't reach here if acknowledged)
-            case .stopped:
-                symbolColor = .systemGray
+            symbolColor = .tertiaryLabelColor
+        } else if session.status == .waitingInput {
+            if isAcknowledged {
+                // Acknowledged waiting: muted colors — seen but still waiting
+                symbolColor = (session.waitingReason == .permissionPrompt)
+                    ? theme.mutedRedColor
+                    : theme.mutedYellowColor
+            } else {
+                // Unacknowledged waiting: bright colors — needs attention
+                symbolColor = (session.waitingReason == .permissionPrompt) ? theme.redColor : theme.yellowColor
             }
+        } else if session.status == .running {
+            symbolColor = theme.greenColor
+        } else {
+            symbolColor = .systemGray
         }
 
         // Set icon using NSMenuItem.image (auto-aligned by macOS)
@@ -927,7 +926,7 @@ $CCSB_TMUX_PANE_TARGET
         if session.isToolRunning == true {
             symbol = "◉"  // Tool running indicator
         } else {
-            symbol = displayStatus.symbol  // Static symbol (●, ◐, ✓)
+            symbol = session.status.symbol  // Static symbol (●, ◐, ✓)
         }
         let symbolAttr = NSAttributedString(
             string: "\(symbol) ",
@@ -967,7 +966,7 @@ $CCSB_TMUX_PANE_TARGET
         // Line 3:   Environment • Status • HH:mm
         let timeStr = formatTime(session.updatedAt)
         let infoAttr = NSAttributedString(
-            string: "\n   \(session.environmentLabel) • \(displayStatus.label) • \(timeStr)",
+            string: "\n   \(session.environmentLabel) • \(session.status.label) • \(timeStr)",
             attributes: [
                 .foregroundColor: secondaryTextColor,
                 .font: NSFont.systemFont(ofSize: 12)
@@ -1041,13 +1040,17 @@ $CCSB_TMUX_PANE_TARGET
         let waitingReason = (status == .waitingInput)
             ? CodexStatusReceiver.shared.getWaitingReason(for: codexSession.cwd)
             : nil
-        let displayStatus: CodexStatus = (isAcked && status == .waitingInput) ? .running : status
         let symbolColor: NSColor
-        if displayStatus == .stopped {
+        if status == .stopped {
             symbolColor = NSColor.systemGray
-        } else if displayStatus == .waitingInput {
+        } else if status == .waitingInput {
             if waitingReason == .idle {
                 symbolColor = NSColor.systemGray
+            } else if isAcked {
+                // Acknowledged waiting: muted colors
+                symbolColor = (waitingReason == .permissionPrompt)
+                    ? theme.mutedRedColor
+                    : theme.mutedYellowColor
             } else {
                 symbolColor = (waitingReason == .permissionPrompt) ? theme.redColor : theme.yellowColor
             }
@@ -1055,7 +1058,7 @@ $CCSB_TMUX_PANE_TARGET
             symbolColor = theme.greenColor
         }
         let symbol: String
-        switch displayStatus {
+        switch status {
         case .running: symbol = "●"
         case .waitingInput: symbol = (waitingReason == .idle) ? "○" : "◐"
         case .stopped: symbol = "✓"
@@ -1103,11 +1106,11 @@ $CCSB_TMUX_PANE_TARGET
         // Line 3:   Environment • Status • HH:mm
         let envLabel = env.displayName
         let statusLabel: String
-        if displayStatus == .waitingInput {
+        if status == .waitingInput {
             if waitingReason == .permissionPrompt { statusLabel = "Permission" }
             else if waitingReason == .idle { statusLabel = "Idle" }
             else { statusLabel = "Waiting" }
-        } else if displayStatus == .stopped {
+        } else if status == .stopped {
             statusLabel = "Stopped"
         } else {
             statusLabel = "Running"

--- a/Sources/CCStatusBarLib/Models/Session.swift
+++ b/Sources/CCStatusBarLib/Models/Session.swift
@@ -25,7 +25,7 @@ struct Session: Codable, Identifiable, Equatable {
     var questionOptions: [String]? = nil  // AskUserQuestion option labels
     var questionSelected: Int? = nil  // AskUserQuestion selected index
     var isToolRunning: Bool?  // true during PreToolUse..PostToolUse (show spinner)
-    var isAcknowledged: Bool?  // true if user has seen this waiting session (show as green)
+    var isAcknowledged: Bool?  // true if user has seen this waiting session (show muted color)
     var displayOrder: Int?  // Display order in menu (stable across restarts, inherited on TTY reuse)
     var isDisambiguated: Bool?  // true if project name was expanded to parent/child format due to duplicate basenames
 

--- a/Sources/CCStatusBarLib/Services/ColorTheme.swift
+++ b/Sources/CCStatusBarLib/Services/ColorTheme.swift
@@ -60,6 +60,16 @@ public enum ColorTheme: String, CaseIterable {
         }
     }
 
+    /// Muted red for acknowledged waiting (permission prompt)
+    public var mutedRedColor: NSColor {
+        redColor.withAlphaComponent(0.5)
+    }
+
+    /// Muted yellow for acknowledged waiting (stop/unknown)
+    public var mutedYellowColor: NSColor {
+        yellowColor.withAlphaComponent(0.5)
+    }
+
     /// Color for idle/no sessions
     public var whiteColor: NSColor {
         switch self {

--- a/Sources/CCStatusBarLib/Views/SessionListWindow.swift
+++ b/Sources/CCStatusBarLib/Views/SessionListWindow.swift
@@ -474,7 +474,7 @@ struct PinnedSessionRowView: View {
                         .font(.system(size: 10))
                         .foregroundColor(Color(white: 0.4))
 
-                    Text(displayStatus.label)
+                    Text(session.status.label)
                         .font(.system(size: 10, weight: .medium))
                         .foregroundColor(statusColor)
                 }
@@ -531,16 +531,9 @@ struct PinnedSessionRowView: View {
         }
     }
 
-    private var displayStatus: SessionStatus {
-        let isAcknowledged = observer.isAcknowledged(sessionId: session.id)
-        if isAcknowledged && session.status == .waitingInput {
-            return .running
-        }
-        return session.status
-    }
-
     private var statusColor: Color {
         let isAcknowledged = observer.isAcknowledged(sessionId: session.id)
+        let theme = AppSettings.colorTheme
 
         // Check if tmux session is detached
         var isTmuxDetached = false
@@ -552,20 +545,21 @@ struct PinnedSessionRowView: View {
             return Color(white: 0.4)
         }
 
-        if !isAcknowledged && session.status == .waitingInput {
+        if session.status == .waitingInput {
+            if isAcknowledged {
+                return session.waitingReason == .permissionPrompt
+                    ? Color(nsColor: theme.mutedRedColor)
+                    : Color(nsColor: theme.mutedYellowColor)
+            }
             return session.waitingReason == .permissionPrompt
-                ? Color(red: 1.0, green: 0.3, blue: 0.3)
-                : Color(red: 1.0, green: 0.7, blue: 0.2)
+                ? Color(nsColor: theme.redColor)
+                : Color(nsColor: theme.yellowColor)
         }
 
-        switch displayStatus {
-        case .running:
-            return Color(red: 0.3, green: 0.85, blue: 0.4)
-        case .waitingInput:
-            return Color(red: 1.0, green: 0.7, blue: 0.2)
-        case .stopped:
-            return Color(white: 0.5)
+        if session.status == .running {
+            return Color(nsColor: theme.greenColor)
         }
+        return Color(white: 0.5)
     }
 
     private func focusSession() {
@@ -722,14 +716,8 @@ struct PinnedCodexSessionRowView: View {
         CodexStatusReceiver.shared.isAcknowledged(cwd: codexSession.cwd)
     }
 
-    /// Display status considering acknowledge state
-    /// Note: idle sessions always show as idle regardless of ack state
-    private var displayStatus: CodexStatus {
-        (isAcked && status == .waitingInput && waitingReason != .idle) ? .running : status
-    }
-
     private var statusLabel: String {
-        switch displayStatus {
+        switch status {
         case .waitingInput:
             if waitingReason == .permissionPrompt { return "Permission" }
             if waitingReason == .idle { return "Idle" }
@@ -742,19 +730,26 @@ struct PinnedCodexSessionRowView: View {
     }
 
     private var statusColor: Color {
+        let theme = AppSettings.colorTheme
+
         if status == .stopped {
             return Color(white: 0.5)
         }
-        if !isAcked && status == .waitingInput {
-            if waitingReason == .permissionPrompt {
-                return Color(red: 1.0, green: 0.3, blue: 0.3)
-            }
+        if status == .waitingInput {
             if waitingReason == .idle {
                 return Color(white: 0.55)
             }
-            return Color(red: 1.0, green: 0.7, blue: 0.2)
+            if isAcked {
+                return waitingReason == .permissionPrompt
+                    ? Color(nsColor: theme.mutedRedColor)
+                    : Color(nsColor: theme.mutedYellowColor)
+            }
+            if waitingReason == .permissionPrompt {
+                return Color(nsColor: theme.redColor)
+            }
+            return Color(nsColor: theme.yellowColor)
         }
-        return Color(red: 0.3, green: 0.85, blue: 0.4)
+        return Color(nsColor: theme.greenColor)
     }
 
     private func focusCodexSession() {


### PR DESCRIPTION
## Summary

Acknowledged waiting sessions were displayed as **"Running" (green)**, making it impossible to distinguish from actually running sessions. Now they show their real **"Waiting"** status with **muted theme colors**.

- Remove `displayStatus` intermediary that mapped acknowledged + waitingInput → running
- Add `mutedRedColor` / `mutedYellowColor` to `ColorTheme` (50% alpha of theme base colors)
- Use `Color(nsColor: theme.*)` in SwiftUI views for theme consistency
- Remove unreachable switch cases from refactor

## Before / After

| State | Before | After |
|-------|--------|-------|
| Waiting (unseen) | Bright red/yellow + "Waiting" | Bright red/yellow + "Waiting" (unchanged) |
| Waiting (acknowledged) | **Green + "Running"** | **Muted red/yellow + "Waiting"** |
| Running | Green + "Running" | Green + "Running" (unchanged) |

## Test plan

- [x] Click a waiting session to acknowledge it — verify it shows muted red/yellow with "Waiting" text (not green "Running")
- [x] Verify unacknowledged waiting sessions still show bright red/yellow
- [x] Verify running sessions still show green
- [x] Switch color themes in Settings — verify muted colors follow the theme
- [x] Verify menu bar dropdown shows same muted colors for acknowledged sessions